### PR TITLE
Fix get_bool_env_var function in app_driver.cpp

### DIFF
--- a/src/core/app_driver.cpp
+++ b/src/core/app_driver.cpp
@@ -65,6 +65,7 @@ bool AppDriver::get_bool_env_var(const char* name, bool default_value) {
         value.begin(), value.end(), value.begin(), [](unsigned char c) { return std::tolower(c); });
 
     if (value == "true" || value == "1" || value == "on") { return true; }
+    if (value == "false" || value == "0" || value == "off") { return false; }
   }
 
   return default_value;


### PR DESCRIPTION
Fix an issue where setting the `stop_on_deadlock` parameter of the scheduler to `false` via the `HOLOSCAN_STOP_ON_DEADLOCK` environment variable was not effective.

Example:

```
HOLOSCAN_STOP_ON_DEADLOCK=0 ./examples/ping_distributed/cpp/ping_distributed --worker --fragments fragment2
```